### PR TITLE
Extend token duration to 30 days

### DIFF
--- a/src/core/Auth/service/AuthService.ts
+++ b/src/core/Auth/service/AuthService.ts
@@ -41,7 +41,7 @@ export class AuthService {
       picture: authInfo.picture,
       company: company.name,
     }
-    return this.jwt.sign(user, { expiresIn: '1d' })
+    return this.jwt.sign(user, { expiresIn: '30d' })
   }
 
   async checkApiKey(header: { apiKey: string }) {


### PR DESCRIPTION
Extend the duration of the authentication token from 1 day to 30 days.

* Modify the `signIn` method in `src/core/Auth/service/AuthService.ts` to change the `expiresIn` value from '1d' to '30d'

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/claranet-it/it-portfolio-manager-backend?shareId=60b78785-72a8-43ee-a8e1-7b6c03817509).